### PR TITLE
Added import for secp256k1addcomplete circuit in the efficientECDSA

### DIFF
--- a/packages/circuits/eff_ecdsa_membership/eff_ecdsa.circom
+++ b/packages/circuits/eff_ecdsa_membership/eff_ecdsa.circom
@@ -1,6 +1,7 @@
 pragma circom 2.1.2;
 
 include "./secp256k1/mul.circom";
+include "./secp256k1/add.circom";
 include "../../../node_modules/circomlib/circuits/bitify.circom";
 
 /**


### PR DESCRIPTION
So currently i found that teh EfficientECDSA is missingan import on the Secp256k1AddComplete from the add.circom.