### PR TITLE
Remove unneeded variable bits

### DIFF
--- a/packages/circuits/eff_ecdsa_membership/eff_ecdsa.circom
+++ b/packages/circuits/eff_ecdsa_membership/eff_ecdsa.circom
@@ -11,7 +11,6 @@ include "../../../node_modules/circomlib/circuits/bitify.circom";
  *  public key validation included.
  */
 template EfficientECDSA() {
-    var bits = 256;
     signal input s;
     signal input Tx; // T = r^-1 * R
     signal input Ty; 

--- a/packages/circuits/eff_ecdsa_membership/eff_ecdsa_to_addr.circom
+++ b/packages/circuits/eff_ecdsa_membership/eff_ecdsa_to_addr.circom
@@ -10,7 +10,6 @@ include "./to_address/zk-identity/eth.circom";
  *  Converts inputted efficient ECDSA signature to an address.
  */
 template EfficientECDSAToAddr() {
-    var bits = 256;
     signal input s;
     signal input Tx; // T = r^-1 * R
     signal input Ty; 


### PR DESCRIPTION
In the EfficientECDSA there was a variable called bits = 256 which is not used in the whole circuit. So i think can just remove this.